### PR TITLE
Hint to agreement of terms of service

### DIFF
--- a/custom_components/volkswagen_we_connect_id/config_flow.py
+++ b/custom_components/volkswagen_we_connect_id/config_flow.py
@@ -68,7 +68,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except AuthentificationError:
             errors["base"] = "invalid_auth"
         except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
+            _LOGGER.exception("Unexpected exception;Possibly missing agreement to the terms of use, visit the VW website!")
             errors["base"] = "unknown"
         else:
             return self.async_create_entry(title=info["title"], data=user_input)


### PR DESCRIPTION
Sometimes logging in to the service does not work. A possible reason for this is that you have not agreed to Volkswagen's updated terms and conditions. As this occasionally happens, I have added a note directly to the logs.